### PR TITLE
fixes: https://github.com/dreamfactorysoftware/dreamfactory/issues/15

### DIFF
--- a/src/Models/CorsConfig.php
+++ b/src/Models/CorsConfig.php
@@ -35,7 +35,7 @@ class CorsConfig extends BaseSystemModel
     /**
      * @var bool
      */
-    public $timestamps = false;
+    public $timestamps = true;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
Also... why were $timestamps = false at all?
Was that important?

Maybe setting up the value to the instance before persisting would do...