### PR TITLE
Fixed Invalid token: Wrong number of segments bug on NodeJs Scripting

### DIFF
--- a/src/Scripting/Engines/NodeJs.php
+++ b/src/Scripting/Engines/NodeJs.php
@@ -118,7 +118,12 @@ _wrapperResult = (function() {
             'x-dreamfactory-session-token': _platform.session.session_token 
         }
     };
-    
+
+    if(_platform.session.session_token == null)
+        _options.headers = {
+                'x-dreamfactory-api-key': _platform.session.api_key
+        };
+
     _event.setReturn = function(content){
         _event.script_result = content;
         console.log(JSON.stringify(_event));


### PR DESCRIPTION
Hi,
With #26 in mind, one bug is that when we want access an internal api from a guest service the only thing we have is `api key`, and in nodejs scripting wrapper [this line](https://github.com/dreamfactorysoftware/df-core/blob/2e85d3d7e3777f8bac2dd7c4d99441910ad315d2/src/Scripting/Engines/NodeJs.php#L118)
cause a bug in AuthCheck middleware, the problem is that in [this line](https://github.com/dreamfactorysoftware/dreamfactory/blob/4ee943071807517a8d0b380e25c11bed48cd5d92/app/Http/Middleware/AuthCheck.php#L54) of AuthCheck, `'null'` string is passed instead of real `null`.