### PR TITLE
Fixed Event Scripts Not Running For Server Side Scripting

### DIFF
--- a/src/Events/PostProcessApiEvent.php
+++ b/src/Events/PostProcessApiEvent.php
@@ -24,7 +24,7 @@ class PostProcessApiEvent extends InterProcessApiEvent
     {
         $this->request = $request;
         $this->response = $response;
-        $name = strtolower($path . '.' . $request->getMethod()) . '.post_process';
+        $name = strtolower($path . '.' . str_replace('/', '.', $resource) . '.' . $request->getMethod()) . '.post_process';
         parent::__construct($name, $resource);
     }
 

--- a/src/Events/PreProcessApiEvent.php
+++ b/src/Events/PreProcessApiEvent.php
@@ -22,7 +22,7 @@ class PreProcessApiEvent extends InterProcessApiEvent
     {
         $this->request = $request;
         $this->response = $response;
-        $name = strtolower($path . '.' . $request->getMethod()) . '.pre_process';
+        $name = strtolower($path . '.' . str_replace('/', '.', $resource) . '.' . $request->getMethod()) . '.pre_process';
         parent::__construct($name, $resource);
     }
 

--- a/src/Events/QueuedApiEvent.php
+++ b/src/Events/QueuedApiEvent.php
@@ -26,7 +26,7 @@ class QueuedApiEvent extends ApiEvent
      */
     public function __construct($path, $request, $response, $resource = null)
     {
-        $name = strtolower($path . '.' . $request->getMethod()) . '.queued';
+        $name = strtolower($path . '.' . str_replace('/', '.', $resource) . '.' . $request->getMethod()) . '.queued';
         parent::__construct($name);
 
         if ($response instanceof RedirectResponse || $response instanceof StreamedResponse) {


### PR DESCRIPTION
Hi,
I have some server side scripts, and need to enable pre_process,post_process or queued_procces on them.

For example i have a service with following path:
GET service-name/sub-path/my-action
that service name is service-name, resource is sub-path/my-action

When i create a post_process for above action from web  admin script name is this:
service-name.sub-path.my-action.get.post_process

but when check log data following script name is logged:
 service-name.get.post_process

that cause to event scripts not running