### PR TITLE
DF-1231 Must delete the old primary key constraint before removing column

### DIFF
--- a/database/migrations/2017_05_13_024529_system_config_update.php
+++ b/database/migrations/2017_05_13_024529_system_config_update.php
@@ -23,6 +23,7 @@ class SystemConfigUpdate extends Migration
         if (Schema::hasColumn('system_config', 'db_version')) {
             Schema::table('system_config', function (Blueprint $t) use ($onDelete) {
                 // delete the old stuff and create the new config
+                $t->dropPrimary('system_config_db_version_primary');
                 $t->dropColumn('db_version');
                 $t->dropColumn('created_date');
                 $t->dropColumn('last_modified_date');


### PR DESCRIPTION
Tested on mysql, sqlite, and sqlsrv databases migrating up from 2.7 to latest develop