### PR TITLE
Add version suffix for tymon/jwt-auth

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "doctrine/dbal":          "~2.5.0",
     "guzzlehttp/guzzle":      "~6.0",
     "symfony/yaml":           "~2.8|~3.0",
-    "tymon/jwt-auth":         "~1.0.0"
+    "tymon/jwt-auth":         "~1.0.0-rc.4.1"
   },
   "require-dev": {
     "phpunit/phpunit": "@stable"


### PR DESCRIPTION
Because we do not have "minimum-stability": "dev" in other composer.json files but the main one, composer cannot resolve jwt-auth package as it has only pre-releases and does not have the exact 1.0.0 release.

This should fix issues like [#5](https://github.com/dreamfactorysoftware/df-azure/issues/5). And we can start using dependabot at full power.