### PR TITLE
Fix CORS Preflight Handling for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
   "prefer-stable": true,
   "require":     {
     "php":                    "^8.0",
-    "fruitcake/laravel-cors": "~3.0.0",
     "doctrine/dbal":          "^3.1.4",
     "guzzlehttp/guzzle":      "~7.4.5",
     "symfony/yaml":           "^6.0",

--- a/routes/routes.php
+++ b/routes/routes.php
@@ -17,7 +17,7 @@ Route::prefix(config('df.api_route_prefix', 'api'))
         $resourcePathPattern = '[0-9a-zA-ZÀ-ÿ-_@&\#\!=,:;\/\^\$\.\|\{\}\[\]\(\)\*\+\?\' ]+';
         $controller = 'DreamFactory\Core\Http\Controllers\RestController';
         // Don't use any() below, or include OPTIONS here, breaks CORS
-        $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'];
+        $verbs = ['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'];
 
         Route::get('', $controller . '@index');
         // Support old versioning in URL, i.e api/v2 and api/v2/service

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -103,19 +103,9 @@ class LaravelServiceProvider extends ServiceProvider
      */
     protected function addMiddleware()
     {
-        // the method name was changed in Laravel 5.4
-        if (method_exists(\Illuminate\Routing\Router::class, 'aliasMiddleware')) {
-            Route::aliasMiddleware('df.auth_check', AuthCheck::class);
-            Route::aliasMiddleware('df.access_check', AccessCheck::class);
-            Route::aliasMiddleware('df.verb_override', VerbOverrides::class);
-        } else {
-            /** @noinspection PhpUndefinedMethodInspection */
-            Route::middleware('df.auth_check', AuthCheck::class);
-            /** @noinspection PhpUndefinedMethodInspection */
-            Route::middleware('df.access_check', AccessCheck::class);
-            /** @noinspection PhpUndefinedMethodInspection */
-            Route::middleware('df.verb_override', VerbOverrides::class);
-        }
+        Route::aliasMiddleware('df.auth_check', AuthCheck::class);
+        Route::aliasMiddleware('df.access_check', AccessCheck::class);
+        Route::aliasMiddleware('df.verb_override', VerbOverrides::class);
 
         /** Add the first user check to the web group */
         Route::prependMiddlewareToGroup('web', FirstUserCheck::class);

--- a/src/Providers/CorsServiceProvider.php
+++ b/src/Providers/CorsServiceProvider.php
@@ -2,9 +2,10 @@
 
 namespace DreamFactory\Core\Providers;
 
-use Fruitcake\Cors\HandleCors;
-use Fruitcake\Cors\CorsService;
+use DreamFactory\Core\Services\DfCorsService;
 use DreamFactory\Core\Models\CorsConfig;
+use Fruitcake\Cors\CorsService;
+use Illuminate\Http\Middleware\HandleCors;
 use Illuminate\Database\QueryException;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
@@ -35,21 +36,15 @@ class CorsServiceProvider extends ServiceProvider
      */
     public function boot(Request $request, Kernel $kernel)
     {
+        $api_prefix = config('df.api_route_prefix', 'api');
+        config(['cors.paths' => [$api_prefix . '/*']]);
+        
         $config = $this->getOptions($request);
         $this->app->singleton(CorsService::class, function () use ($config){
-            return new CorsService($config);
+            return new DfCorsService($config);
         });
 
-        /** @noinspection PhpUndefinedMethodInspection */
-        //$this->app['router']->middleware('cors', HandleCors::class);
-
-        if (method_exists(\Illuminate\Routing\Router::class, 'aliasMiddleware')) {
-            Route::aliasMiddleware('df.cors', HandleCors::class);
-        } else {
-            /** @noinspection PhpUndefinedMethodInspection */
-            Route::middleware('df.cors', HandleCors::class);
-        }
-
+        Route::aliasMiddleware('df.cors', HandleCors::class);
         Route::prependMiddlewareToGroup('df.api', 'df.cors');
     }
 

--- a/src/Services/DfCorsService.php
+++ b/src/Services/DfCorsService.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DreamFactory\Core\Services;
+
+use Fruitcake\Cors\CorsService;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DfCorsService extends CorsService
+{
+    /** @var string[] */
+    private array $allowedMethodsCopy = [];
+
+
+    public function setOptions(array $options): void
+    {
+        $this->allowedMethodsCopy = $options['allowedMethods'] ?? $options['allowed_methods'] ?? $this->allowedMethodsCopy;
+        parent::setOptions($options);
+    }
+    
+    public function handlePreflightRequest(Request $request): Response
+    {
+        $response = new Response();
+
+        $requestMethod = strtoupper($request->headers->get('Access-Control-Request-Method'));
+        if(!in_array($requestMethod, $this->allowedMethodsCopy)) {
+            $response->setStatusCode(405, 'Method not allowed');
+        } else {
+            $response->setStatusCode(204);
+        }
+        
+        return $this->addPreflightRequestHeaders($response, $request);
+    }
+}


### PR DESCRIPTION
- Switch to native Laravel CORS middleware
- Dynamically define CORS paths
- Extend Fruitcake\CorsService to handle HTTP Methods