### PR TITLE
Pass length warning

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -131,6 +131,13 @@ class Setup extends Command
                         continue;
                     }
                     
+                    // Validate password confirmation
+                    if ($password !== $passwordConfirm) {
+                        $this->error('Passwords do not match. Please try again.');
+                        $password = null; // Reset password to trigger re-prompt
+                        continue;
+                    }
+                    
                     $validPassword = true;
                 }
                 


### PR DESCRIPTION
added some logic for pass length, so that if pass < 16 or if pass mismatches will loop back only on password entry. 