### PR TITLE
[DP-685]

### DIFF
--- a/src/Components/ServiceHealthChecker.php
+++ b/src/Components/ServiceHealthChecker.php
@@ -5,8 +5,8 @@ namespace DreamFactory\Core\Components;
 use DreamFactory\Core\Models\Service;
 use DreamFactory\Core\Enums\Verbs;
 use DreamFactory\Core\Enums\ServiceTypeGroups;
-use ServiceManager; // Facade
-use Log;          // Facade
+use ServiceManager;
+use Log;
 
 class ServiceHealthChecker
 {

--- a/src/Components/ServiceHealthChecker.php
+++ b/src/Components/ServiceHealthChecker.php
@@ -5,7 +5,6 @@ namespace DreamFactory\Core\Components;
 use DreamFactory\Core\Models\Service;
 use DreamFactory\Core\Enums\Verbs;
 use DreamFactory\Core\Enums\ServiceTypeGroups;
-use DreamFactory\Core\Exceptions\InternalServerErrorException;
 use ServiceManager; // Facade
 use Log;          // Facade
 
@@ -57,7 +56,6 @@ class ServiceHealthChecker
                 return true;
             }
         } catch (\Exception $e) {
-            // Catches exceptions from ServiceManager::handleRequest itself (e.g., service not found, connection issues)
             $summary = 'Exception during API health check: ' . $e->getMessage();
             $this->logFailure($summary, $e, $logContext);
             return false;

--- a/src/Components/ServiceHealthChecker.php
+++ b/src/Components/ServiceHealthChecker.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace DreamFactory\Core\Components;
+
+use DreamFactory\Core\Models\Service;
+use DreamFactory\Core\Enums\Verbs;
+use DreamFactory\Core\Enums\ServiceTypeGroups;
+use DreamFactory\Core\Exceptions\InternalServerErrorException;
+use ServiceManager; // Facade
+use Log;          // Facade
+
+class ServiceHealthChecker
+{
+    /**
+     * Performs a post-creation health check on the given service.
+     * Deactivates the service if the check fails.
+     *
+     * @param Service $service The service to check.
+     * @return bool True if the health check is successful, false otherwise.
+     */
+    public function check(Service $service): bool
+    {
+        $request_type = Verbs::GET;
+        $testResourcePath = '/';
+        $typeInfo = ServiceManager::getServiceType($service->type);
+
+        if ($typeInfo) {
+            switch ($typeInfo->getGroup()) {
+                case ServiceTypeGroups::DATABASE:
+                    $testResourcePath = '_table';
+                    break;
+                default:
+                    return true;
+                    break;
+            }
+        }
+
+        $logContext = [
+            'service_name'  => $service->name,
+            'service_type'  => $service->type,
+            'resource_path' => $testResourcePath,
+            'request_type'  => $request_type,
+        ];
+
+        Log::info('Performing post-creation API health check.', $logContext);
+
+        try {
+            $result = ServiceManager::handleRequest($service->name, $request_type, $testResourcePath);
+
+            if ($result->getStatusCode() >= 300) {
+                $errorContent = $result->getContent();
+                $errorMessage = isset($errorContent['error']['message']) ? $errorContent['error']['message'] : 'No specific error message in response.';
+                $summary = 'API check returned status ' . $result->getStatusCode() . '. Message: ' . $errorMessage;
+                $this->logFailure($summary, null, $logContext);
+                return false;
+            } else {
+                return true;
+            }
+        } catch (\Exception $e) {
+            // Catches exceptions from ServiceManager::handleRequest itself (e.g., service not found, connection issues)
+            $summary = 'Exception during API health check: ' . $e->getMessage();
+            $this->logFailure($summary, $e, $logContext);
+            return false;
+        }
+    }
+
+    /**
+     * Logs a failed health check.
+     *
+     * @param Service $service
+     * @param string $failureSummary
+     * @param \Exception|null $rootCauseException
+     * @param array $logContext Base context for logging.
+     */
+    protected function logFailure(string $failureSummary, ?\Exception $rootCauseException = null, array $logContext = []): void
+    {
+        $fullLogContext = array_merge($logContext, ['summary' => $failureSummary]);
+        if ($rootCauseException) {
+            $fullLogContext['root_cause_class'] = get_class($rootCauseException);
+            $fullLogContext['root_cause_message'] = $rootCauseException->getMessage();
+        }
+        Log::error('Post-creation API health check FAILED.', $fullLogContext);
+    }
+}

--- a/src/Components/ServiceHealthChecker.php
+++ b/src/Components/ServiceHealthChecker.php
@@ -12,7 +12,6 @@ class ServiceHealthChecker
 {
     /**
      * Performs a post-creation health check on the given service.
-     * Deactivates the service if the check fails.
      *
      * @param Service $service The service to check.
      * @return bool True if the health check is successful, false otherwise.


### PR DESCRIPTION
Implementation of the service health checker for the Database APIs to ensure that UpdateSender is utilized only when the database API is configured successfully. 

This service currently checks only Database APIs, since it is the only type of service that already has post-creation validation on the right in the [df-service-details.component.ts file](https://github.com/dreamfactorysoftware/df-admin-interface/blob/4c507dabe6a3ff2c1c41e04cf4519cbb3c1c83d1/src/app/adf-services/df-service-details/df-service-details.component.ts#L628C20-L628C53), which actually caused the issue described in the DP-685.

We made this service flexible to provide a way to add similar post-creation health checkers for other API types in the future.