### PR TITLE
Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,19 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "php":                    "^8.0",
-    "doctrine/dbal":          "^3.1.4",
+    "php":                    "^8.3",
     "guzzlehttp/guzzle":      "^7.8",
-    "symfony/yaml":           "^6.0",
+    "laravel/helpers":        "^1.8",
+    "symfony/yaml":           "^6.0|^7.0",
     "tymon/jwt-auth":         "^2.1.0",
     "dreamfactory/df-system": "~0.6.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework":      "^13.7",
+    "mockery/mockery":        "^1.6",
+    "nunomaduro/collision":   "^8.6",
+    "orchestra/testbench":    "^11.0",
+    "phpunit/phpunit":        "^11.5.3"
   },
   "autoload":    {
     "files": [

--- a/src/Database/Connectors/SQLiteConnector.php
+++ b/src/Database/Connectors/SQLiteConnector.php
@@ -10,7 +10,7 @@ class SQLiteConnector extends \Illuminate\Database\Connectors\SQLiteConnector
      * @param  array  $config
      * @return \PDO
      */
-    public function connect(array $config)
+    public function connect(array $config): \PDO
     {
         $options = $this->getOptions($config);
 

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -1,11 +1,10 @@
 <?php namespace DreamFactory\Core\Http\Controllers;
 
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class Controller extends BaseController
 {
-    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+    use AuthorizesRequests, ValidatesRequests;
 }

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -60,11 +60,8 @@ class LaravelServiceProvider extends ServiceProvider
 
         $this->registerOtherProviders();
 
-        // add routes
-        /** @noinspection PhpUndefinedMethodInspection */
-        if (!$this->app->routesAreCached()) {
-            include __DIR__ . '/../routes/routes.php';
-        }
+        // add routes (loadRoutesFrom handles the route-cache check internally)
+        $this->loadRoutesFrom(__DIR__ . '/../routes/routes.php');
 
         // add commands, https://laravel.com/docs/5.4/packages#commands
         $this->addCommands();
@@ -83,8 +80,10 @@ class LaravelServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // Register MongoDB provider first
-        $this->app->register(MongoDBServiceProvider::class);
+        // Register MongoDB provider first (gated — package is optional)
+        if (class_exists(MongoDBServiceProvider::class)) {
+            $this->app->register(MongoDBServiceProvider::class);
+        }
 
         // merge in df config, https://laravel.com/docs/5.4/packages#resources
         $this->mergeConfigFrom(__DIR__ . '/../config/df.php', 'df');
@@ -117,8 +116,10 @@ class LaravelServiceProvider extends ServiceProvider
         Route::aliasMiddleware('df.access_check', AccessCheck::class);
         Route::aliasMiddleware('df.verb_override', VerbOverrides::class);
 
-        /** Add the first user check to the web group */
-        Route::prependMiddlewareToGroup('web', FirstUserCheck::class);
+        /** Add the first user check to the web group (gated — `web` may not be defined in API-only apps) */
+        if (Route::hasMiddlewareGroup('web')) {
+            Route::prependMiddlewareToGroup('web', FirstUserCheck::class);
+        }
 
         $middleware = [
             'df.verb_override',
@@ -183,7 +184,10 @@ class LaravelServiceProvider extends ServiceProvider
 
     protected function registerOtherProviders()
     {
-        // use CORS
-        $this->app->register(CorsServiceProvider::class);
+        // use CORS (gated — Laravel HandleCors middleware ships in framework so the
+        // provider class is always available, but keep the gate symmetric/defensive)
+        if (class_exists(CorsServiceProvider::class)) {
+            $this->app->register(CorsServiceProvider::class);
+        }
     }
 }

--- a/src/Models/NoDbModel.php
+++ b/src/Models/NoDbModel.php
@@ -74,15 +74,25 @@ class NoDbModel implements Arrayable, Jsonable, JsonSerializable
         return $casts;
     }
 
-    // not sure why Laravel has these are in the HasAttributes trait instead of the model, but they need simplification
+    // The HasAttributes trait calls $this->getDates() and $this->getDateFormat() internally
+    // during attributesToArray(). The trait's own getDates() implementation depends on
+    // usesTimestamps() / $dates, neither of which NoDbModel inherits (it doesn't extend
+    // Model and doesn't use HasTimestamps). We provide stub overrides that short-circuit
+    // the date handling so attributesToArray() works for this Model-less use case.
+    //
+    // Historical note: Eloquent's Model::getDates() was removed in Laravel 10, but the
+    // method still lives in HasAttributes and is invoked from inside the trait, so the
+    // override remains necessary as long as NoDbModel uses HasAttributes directly.
     public function getDates()
     {
-        return $this->dates;
+        return property_exists($this, 'dates') ? (array) $this->dates : [];
     }
 
     protected function getDateFormat()
     {
-        return $this->dateFormat;
+        return property_exists($this, 'dateFormat') && $this->dateFormat
+            ? $this->dateFormat
+            : 'Y-m-d H:i:s';
     }
 
     /**

--- a/src/Providers/CorsServiceProvider.php
+++ b/src/Providers/CorsServiceProvider.php
@@ -7,7 +7,6 @@ use DreamFactory\Core\Models\CorsConfig;
 use Fruitcake\Cors\CorsService;
 use Illuminate\Http\Middleware\HandleCors;
 use Illuminate\Database\QueryException;
-use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -31,10 +30,9 @@ class CorsServiceProvider extends ServiceProvider
      * Add the Cors middleware to the router.
      *
      * @param Request $request
-     * @param Kernel  $kernel
      * @throws \Exception
      */
-    public function boot(Request $request, Kernel $kernel)
+    public function boot(Request $request)
     {
         $api_prefix = config('df.api_route_prefix', 'api');
         config(['cors.paths' => [$api_prefix . '/*']]);

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -37,7 +37,7 @@ class TestCase extends LaravelTestCase
     /**
      * Runs before every test class.
      */
-    public static function setupBeforeClass(): void
+    public static function setUpBeforeClass(): void
     {
         echo "\n------------------------------------------------------------------------------\n";
         echo "Running test: " . get_called_class() . "\n";
@@ -110,15 +110,67 @@ class TestCase extends LaravelTestCase
     /**
      * Creates the application.
      *
+     * Consuming applications should override this if the Laravel-style
+     * bootstrap path differs from the conventional `bootstrap/app.php`
+     * relative to the host project root. The base path is resolved from
+     * the consumer's working tree (parent of the running phpunit binary)
+     * rather than the current working directory, so tests can be invoked
+     * from any cwd.
+     *
      * @return \Illuminate\Foundation\Application
      */
     public function createApplication()
     {
-        $app = require './bootstrap/app.php';
+        $bootstrap = $this->resolveBootstrapPath();
 
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        /** @var \Illuminate\Foundation\Application $app */
+        $app = require $bootstrap;
+
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app;
+    }
+
+    /**
+     * Resolve the path to the Laravel application bootstrap file.
+     *
+     * Order of resolution:
+     *   1. DF_TEST_BOOTSTRAP env var (explicit override)
+     *   2. df-core's own ./bootstrap/app.php (when df-core has its own)
+     *   3. Walk up from this file looking for a vendor/.. host project root
+     *
+     * @return string
+     */
+    protected function resolveBootstrapPath(): string
+    {
+        if ($override = getenv('DF_TEST_BOOTSTRAP')) {
+            return $override;
+        }
+
+        // df-core itself: __DIR__ = src/Testing, so root is two levels up.
+        $localCandidate = dirname(__DIR__, 2) . '/bootstrap/app.php';
+        if (file_exists($localCandidate)) {
+            return $localCandidate;
+        }
+
+        // Installed under a host project's vendor/dreamfactory/df-core/src/Testing
+        // → walk up to the host project root (parent of vendor/).
+        $dir = __DIR__;
+        for ($i = 0; $i < 10; $i++) {
+            $candidate = $dir . '/bootstrap/app.php';
+            if (file_exists($candidate) && is_file($dir . '/artisan')) {
+                return $candidate;
+            }
+            $parent = dirname($dir);
+            if ($parent === $dir) {
+                break;
+            }
+            $dir = $parent;
+        }
+
+        throw new \RuntimeException(
+            'Unable to locate bootstrap/app.php. Set DF_TEST_BOOTSTRAP env var to its absolute path.'
+        );
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Arr;
+
 if (!function_exists('to_bool')) {
     /**
      * Convert any value to boolean value.
@@ -44,7 +46,7 @@ if (!function_exists('array_get_bool')) {
      */
     function array_get_bool($array, $key, $default = false)
     {
-        return to_bool(array_get($array, $key, $default));
+        return to_bool(Arr::get($array, $key, $default));
     }
 }
 
@@ -65,9 +67,9 @@ if (!function_exists('array_by_key_value')) {
     {
         if (is_array($array)) {
             foreach ($array as $item) {
-                if ($value === array_get($item, $key)) {
+                if ($value === Arr::get($item, $key)) {
                     if ($returnKey) {
-                        return array_get($item, $returnKey);
+                        return Arr::get($item, $returnKey);
                     } else {
                         return $item;
                     }
@@ -140,7 +142,7 @@ if (!function_exists('array_get_or')) {
     {
         $out = null;
         foreach ($keys as $key) {
-            $out = array_get($data, $key);
+            $out = Arr::get($data, $key);
             if ($out !== null) {
                 break;
             }


### PR DESCRIPTION
## Summary

Wave 0 of the 53-package Laravel 11 → 13 upgrade campaign. This PR
makes `df-core` compose, autoload, and runtime-load cleanly under
Laravel 13.7 while keeping the package framework-agnostic in its
production `require` (host application pins the framework version).

Tracks main-app L13 Shift PR [dreamfactory/dreamfactory#578](https://github.com/dreamfactorysoftware/dreamfactory/pull/578).
Companion to df-commercial gold release 7.4.5.

## Changes (8 files)

### `composer.json`
| Dep | Before | After | Why |
|-----|--------|-------|-----|
| `php` | `^8.0` | `^8.3` | L13 minimum; matches main app |
| `doctrine/dbal` | `^3.1.4` | _removed_ | Zero `src/` usage |
| `symfony/yaml` | `^6.0` | `^6.0\|^7.0` | L13 ships Symfony 7 |
| `laravel/helpers` | _none_ | `^1.8` (require) | Polyfills the 346 `array_get`/`camel_case`/`array_except` sites still in df-core; production-required so consumers don't need to add it |
| `laravel/framework` | _none_ | `^13.7` (require-**dev**) | Test-only — keeps df-core framework-agnostic in `require` |
| `phpunit/phpunit` | `@stable` | `^11.5.3` | L13-compat |
| `mockery/mockery` | _none_ | `^1.6` | Test stack |
| `nunomaduro/collision` | _none_ | `^8.6` | Test stack |
| `orchestra/testbench` | _none_ | `^11.0` | **Note:** `^10` pins to Laravel 12; `^11` is the L13-compat track |

### `src/Http/Controllers/Controller.php`
Removed `DispatchesJobs` trait. The trait was removed from Laravel core in **Laravel 11** ([upgrade guide](https://laravel.com/docs/11.x/upgrade)). Verified zero `$this->dispatch()` callers anywhere in df-core. Sibling-package `df-script` uses the trait directly — that's its own future fix, not blocked by this change.

### `src/LaravelServiceProvider.php`
Three changes:
1. Replaced `include __DIR__.'/../routes/routes.php'` with `$this->loadRoutesFrom()` — handles route-cache check internally, idiomatic for L11+.
2. Gated `Route::prependMiddlewareToGroup('web', FirstUserCheck::class)` with `Route::hasMiddlewareGroup('web')`. L13's API-only application stack does not register a `web` group; the un-gated call would throw `InvalidArgumentException`.
3. Gated `MongoDBServiceProvider` and `CorsServiceProvider` registrations with `class_exists()` for graceful degradation when the optional package isn't installed.

### `src/Providers/CorsServiceProvider.php`
Dropped the unused `Kernel $kernel` parameter from `boot()` (and its `use Illuminate\Contracts\Http\Kernel;`). 

**Important verification:** Laravel 13.7's `Illuminate\Http\Middleware\HandleCors` still typehints `Fruitcake\Cors\CorsService` in its constructor (Laravel did NOT migrate to a first-party `Illuminate\Http\CorsService` — see `vendor/laravel/framework/src/Illuminate/Http/Middleware/HandleCors.php`). The existing `singleton(Fruitcake\Cors\CorsService::class, ...)` binding is therefore correct and unchanged. Same for `DfCorsService extends Fruitcake\Cors\CorsService`.

### `src/Models/NoDbModel.php`
Hardened the `getDates()` / `getDateFormat()` overrides instead of removing them. **Removing them broke runtime** — verified by smoke test that without the override, `attributesToArray()` → `addDateAttributesToArray()` → `getDates()` (trait fallback) → `usesTimestamps()` → fatal `Call to undefined method`, because `NoDbModel` doesn't extend `Model` and doesn't use `HasTimestamps`. The new stubs short-circuit safely whether `$dates` / `$dateFormat` are set on the subclass or not.

### `src/Database/Connectors/SQLiteConnector.php`
Added `: \PDO` covariant return type to `connect()`. Parent has no return type; widening is allowed.

### `src/Testing/TestCase.php`
1. Renamed `setupBeforeClass` → `setUpBeforeClass` (PHPUnit 11 is case-sensitive; PHPUnit 9 also was, so this was a latent bug).
2. Replaced the broken `require './bootstrap/app.php'` (relative to the runner's cwd, never reliable) with a `resolveBootstrapPath()` helper that:
   - Honors `DF_TEST_BOOTSTRAP` env override.
   - Falls back to df-core's own `bootstrap/app.php` if present.
   - Walks up from the file location to find a host-app root with both `bootstrap/app.php` and `artisan`.

### `src/helpers.php`
Replaced the four internal `array_get()` calls inside df-core's own helpers with `Illuminate\Support\Arr::get()`. df-core's helpers no longer depend on the `laravel/helpers` polyfill being installed at runtime. (The 346 `array_get` sites elsewhere in models/services/components stay polyfilled — out of scope for this PR; follow-up will migrate them to `Arr::`/`Str::`.)

## Test plan

### Stage 1 — package-isolated
- [x] `composer validate --strict`: passes
- [x] `composer install` (with path-repo aliases for the **pre-existing** structural `df-system ↔ df-core` circular `require` — this is not new in L13): resolves `laravel/framework v13.7.0`, `phpunit/phpunit 11.5.55`, `orchestra/testbench v11.1.0`, `tymon/jwt-auth 2.3.0`, `symfony/yaml v7.4.8`
- [x] `php -l` across all `src/` + `tests/` files: zero parse errors
- [x] Reflection load of all 10 critical public classes succeeds
- [x] Functional smoke: `NoDbModel::toArray()` and `BaseModel::toArray()` run without fatal; `DfCorsService::__construct()` works

### Stage 2 — integration with Shift'd main app (`shift-173254`)
- [x] Worktree of `shift-173254` + path-repo override pointing at this branch
- [x] `composer update dreamfactory/df-core`: succeeds
- [x] All 10 critical df-core classes load via reflection inside the host app's autoloader
- [ ] `php artisan test` — **NOT RUN**: blocked by sibling packages (`df-file`, `df-aws`, `df-mongo-logs`, etc.) not yet upgraded. `df-mongo-logs` requires `jenssegers/mongodb` which pins `illuminate/support ^10.0|^11`, blocking L13 resolution. **Tolerated** per Wave 0 plan; sibling upgrades are Wave 1+.

### Stage 3 — review
Self-review against the diff caught one critical spec error before commit (the spec said "remove `getDates()` from NoDbModel — dead code"; runtime smoke test proved it's load-bearing for the trait composition). Restored with hardening.

## Reviewer notes / key risks

1. **`NoDbModel::getDates()` is load-bearing.** Do not remove. The HasAttributes trait calls it during `attributesToArray()`, and NoDbModel can't satisfy the trait's default implementation because it doesn't extend Model. This was the spec's most important false-positive.
2. **Laravel 13.7 still uses `Fruitcake\Cors\CorsService`.** There is no `Illuminate\Http\CorsService` in L13.7. Verified directly against `vendor/laravel/framework/src/Illuminate/Http/Middleware/HandleCors.php`.
3. **`orchestra/testbench` constraint:** must be `^11.0`, not `^10.0`. v10 pins L12.
4. **Pre-existing circular require:** `df-core` requires `df-system ~0.6.2`, and `df-system` requires `df-core ~1.0`. df-core's `dev-master` doesn't satisfy `~1.0`, so standalone `composer install` has never worked on master and still doesn't. Not introduced by this PR. Stage 1 used path-repo aliases as a workaround.
5. **`df-script` uses `DispatchesJobs` directly** (not via df-core's `Controller`). It will need its own L13 fix (the trait was removed in L11). Out of scope for this PR; flagged for Wave 1+.

## Generalizable insights for sibling-package waves

- **Spec-vs-reality drift on Cors:** Don't trust unverified upgrade-guide claims about Laravel-internal Cors changes. Always grep `vendor/laravel/framework/.../HandleCors.php` for the actual constructor typehint.
- **Trait-method overrides that look dead may not be:** Eloquent traits call `$this->method()` internally. If a child class uses the trait directly (not via `Model`), removing the override can blow up the trait chain. Always smoke-test `toArray()` / `jsonSerialize()`.
- **`orchestra/testbench` major-version tracks Laravel:** v10 → L12, v11 → L13. Don't carry over the spec's `^10`.
- **`web` middleware group is API-only-stack-optional in L13.** Always gate `prependMiddlewareToGroup('web', ...)`.
- **`DispatchesJobs` was removed in L11**, not L13. Sibling packages with direct `use Illuminate\Foundation\Bus\DispatchesJobs;` will fatal at autoload time once they're upgraded.
- **`PHPUnit 11` is case-sensitive on `setUpBeforeClass`.** Audit all `setupBeforeClass` typos in sibling packages — this was latent on master.