### PR TITLE
fix(cors): autoload Eloquent\Collection before cache read on PHP 8.5

### DIFF
--- a/src/Providers/CorsServiceProvider.php
+++ b/src/Providers/CorsServiceProvider.php
@@ -96,10 +96,27 @@ class CorsServiceProvider extends ServiceProvider
      */
     protected function getCorsConfigs()
     {
+        // Force-load Eloquent's Collection class before reading from the cache.
+        // CorsServiceProvider::boot() runs early enough that, if the cache
+        // backend (Redis, file, etc.) returns a serialized Collection, PHP's
+        // unserialize() can fire before the class has been autoloaded — in
+        // which case it returns __PHP_Incomplete_Class, which is unusable.
+        // Touching the class name here triggers PSR-4 autoload up front.
+        class_exists(\Illuminate\Database\Eloquent\Collection::class);
+
         try {
             $cors = Cache::remember(CorsConfig::CACHE_KEY, \Config::get('df.default_cache_ttl'), function (){
                 return CorsConfig::whereEnabled(true)->get();
             });
+
+            // Defensive: if the cached value still came back as something
+            // other than a Collection (cache cross-contamination across
+            // backends, persisted __PHP_Incomplete_Class, etc.), drop the
+            // entry and re-fetch fresh.
+            if (!$cors instanceof \Illuminate\Support\Collection) {
+                Cache::forget(CorsConfig::CACHE_KEY);
+                $cors = CorsConfig::whereEnabled(true)->get();
+            }
 
             return $cors;
         } catch (\Exception $e) {


### PR DESCRIPTION
## Summary

Fixes a fatal `Attempt to read property "path" on string` thrown from `CorsServiceProvider::getOptions()` (line 65) on **PHP 8.5 + Redis cache + Laravel 13**. The bug is a class-autoload race during early ServiceProvider boot and is **invisible to callers** because the fatal happens before Laravel's logger is bootstrapped — visible to the user only as a silent empty-body 500.

Closes the runtime smoke-test failure surfaced by the PHP 8.5 + L13 functional verification (df-base-img PR https://github.com/dreamfactorysoftware/df-docker-base/pull/18).

## Root cause

`CorsServiceProvider::getCorsConfigs()` calls `Cache::remember(CorsConfig::CACHE_KEY, ...)`. On a cache hit, `Illuminate\Cache\RedisStore::get()` retrieves the serialized payload from Redis and calls `unserialize()` on it.

When that `unserialize()` call runs **before** `Illuminate\Database\Eloquent\Collection` has been autoloaded by Composer, PHP's serializer can't resolve the class and silently returns `__PHP_Incomplete_Class` instead. The subsequent `foreach ($configs as $config)` then iterates malformed entries — at which point `$config->path` becomes `<string>->path` and PHP 8.5 fatals with `ErrorException("Attempt to read property 'path' on string")`.

Empirically reproduced: `unserialize()` on the raw Redis bytes from outside Laravel's bootstrap returns a normal `Illuminate\Database\Eloquent\Collection` with the expected items. From inside `Cache::get()` during early `ServiceProvider::boot()`, it returns `__PHP_Incomplete_Class`. The class IS available later (the same code works in `php artisan list` after bootstrap completes), so this is timing/order-sensitive — exactly the kind of regression that's invisible to autoload-only verification.

This bug was masked on Laravel 11 because the framework's class-load order during boot happened to touch `Eloquent\Collection` before our ServiceProvider ran.

## Fix

Two-part defense in `getCorsConfigs()`:

1. **Force autoload up front:** `class_exists(\Illuminate\Database\Eloquent\Collection::class)` triggers PSR-4 autoload before `Cache::get` runs, guaranteeing the class is available when `unserialize()` rehydrates it.

2. **Type-guard with re-fetch:** if the cache nevertheless returns a non-`Collection` value (cache cross-contamination across backends, persisted incomplete classes from older runs, etc.), drop the bad entry and re-fetch fresh from the database. This makes the path robust to any future deserialization edge case.

Net change: 17 added lines, 0 removed, no behavior change on the happy path.

## Verification

Live test against PHP 8.5.5 + Laravel 13.8.0 + Redis predis 2.x:

**Before fix:**
- `GET /api/v2/system/environment` → silent 500, empty body
- Stack trace pinpoints `CorsServiceProvider.php:65` ($config->path on a string)

**After fix:**
- `GET /api/v2/system/environment` → **400** with proper JSON: `{"error":{"code":400,"message":"No session token (JWT) or API Key detected..."}}` (expected unauthenticated response)
- `GET /` → **302** redirect to `/setup` (first-time-setup flow, also expected)
- Full middleware stack runs cleanly: AccessCheck → AuthCheck → VerbOverrides → HandleCors → MCP → routing → kernel handle

## Compat note

The fix is conservative — `class_exists()` is a no-op when the class is already loaded. PHP 8.3 / Laravel 11 paths are unaffected.