### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,15 +30,19 @@
   "minimum-stability": "dev",
   "prefer-stable": true,
   "require":     {
-    "php":                    "^8.0",
-    "doctrine/dbal":          "^3.1.4",
+    "php":                    "^8.3",
     "guzzlehttp/guzzle":      "^7.8",
-    "symfony/yaml":           "^6.0",
+    "laravel/helpers":        "^1.8",
+    "symfony/yaml":           "^6.0|^7.0",
     "tymon/jwt-auth":         "^2.1.0",
     "dreamfactory/df-system": "~0.6.2"
   },
   "require-dev": {
-    "phpunit/phpunit": "@stable"
+    "laravel/framework":      "^13.7",
+    "mockery/mockery":        "^1.6",
+    "nunomaduro/collision":   "^8.6",
+    "orchestra/testbench":    "^11.0",
+    "phpunit/phpunit":        "^11.5.3"
   },
   "autoload":    {
     "files": [

--- a/src/Components/Cacheable.php
+++ b/src/Components/Cacheable.php
@@ -94,9 +94,53 @@ trait Cacheable
      */
     public function getFromCache($key, $default = null)
     {
-        $fullKey = $this->makeCacheKey($key);
+        // PHP 8.5 + Laravel 13 unserialize-time autoload race fix.
+        // Many service caches store typed objects (TableSchema, ColumnSchema,
+        // RelationSchema, NamedResourceSchema, FunctionSchema, ProcedureSchema,
+        // ParameterSchema, RoutineSchema, Eloquent\Collection). On PHP 8.5
+        // the cache backend's unserialize() can fire before the autoloader
+        // has loaded those classes, returning __PHP_Incomplete_Class. Force
+        // PSR-4 autoload up front so the rehydrated objects are real.
+        class_exists(\DreamFactory\Core\Database\Schema\NamedResourceSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\TableSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\ColumnSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\RelationSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\FunctionSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\ProcedureSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\ParameterSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\RoutineSchema::class);
 
-        return Cache::get($fullKey, $default);
+        $fullKey = $this->makeCacheKey($key);
+        $value = Cache::get($fullKey, $default);
+
+        // Defensive: detect __PHP_Incomplete_Class anywhere in the result and
+        // drop the cache entry so the next caller will recompute. Walks one
+        // level deep into arrays (the typical shape — `tables` map etc.).
+        if ($this->cacheValueIsIncomplete($value)) {
+            Cache::forget($fullKey);
+            return $default;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param mixed $value
+     * @return bool true if value is or contains a PHP_Incomplete_Class
+     */
+    protected function cacheValueIsIncomplete($value)
+    {
+        if ($value instanceof \__PHP_Incomplete_Class) {
+            return true;
+        }
+        if (is_array($value)) {
+            foreach ($value as $entry) {
+                if ($entry instanceof \__PHP_Incomplete_Class) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/Components/InternalServiceRequest.php
+++ b/src/Components/InternalServiceRequest.php
@@ -327,6 +327,14 @@ class InternalServiceRequest implements ServiceRequestInterface
     {
         try {
             $payload = $this->getPayloadData();
+            // setPayloadData() is strict-typed array, but getPayloadData() can
+            // return a string when the request body is text/plain (or any
+            // non-array content). Normalize here so toArray()'s output is
+            // always safe to feed back through mergeFromArray() / setPayloadData().
+            // The raw body is still available via the 'content' key below.
+            if (!is_array($payload)) {
+                $payload = [];
+            }
         } catch (\Exception $ex) {
             $payload = null;
         }
@@ -361,7 +369,15 @@ class InternalServiceRequest implements ServiceRequestInterface
             $this->setHeaders(array_get($data, 'headers'));
         }
         if (array_key_exists('payload', $data)) {
-            $this->setPayloadData(array_get($data, 'payload'));
+            $payload = array_get($data, 'payload');
+            // Defense in depth: only forward array-shaped payloads. Non-array
+            // values can arrive when an event script's modified result is
+            // round-tripped back, or when an upstream caller hasn't normalized
+            // its input. Skipping silently here matches the prior loose-typed
+            // behavior that worked before setPayloadData was strict-typed.
+            if (is_array($payload)) {
+                $this->setPayloadData($payload);
+            }
         }
         if (array_key_exists('content', $data)) {
             $content = array_get($data, 'content');

--- a/src/Database/Connectors/SQLiteConnector.php
+++ b/src/Database/Connectors/SQLiteConnector.php
@@ -10,7 +10,7 @@ class SQLiteConnector extends \Illuminate\Database\Connectors\SQLiteConnector
      * @param  array  $config
      * @return \PDO
      */
-    public function connect(array $config)
+    public function connect(array $config): \PDO
     {
         $options = $this->getOptions($config);
 

--- a/src/Enums/ServiceTypeGroups.php
+++ b/src/Enums/ServiceTypeGroups.php
@@ -48,4 +48,6 @@ class ServiceTypeGroups extends FactoryEnum
     const MCP = 'MCP';
 
     const AI = 'AI';
+
+    const AI_CHAT = 'AI Chat';
 }

--- a/src/Http/Controllers/Controller.php
+++ b/src/Http/Controllers/Controller.php
@@ -1,11 +1,10 @@
 <?php namespace DreamFactory\Core\Http\Controllers;
 
-use Illuminate\Foundation\Bus\DispatchesJobs;
 use Illuminate\Routing\Controller as BaseController;
 use Illuminate\Foundation\Validation\ValidatesRequests;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 
 class Controller extends BaseController
 {
-    use AuthorizesRequests, DispatchesJobs, ValidatesRequests;
+    use AuthorizesRequests, ValidatesRequests;
 }

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -60,11 +60,8 @@ class LaravelServiceProvider extends ServiceProvider
 
         $this->registerOtherProviders();
 
-        // add routes
-        /** @noinspection PhpUndefinedMethodInspection */
-        if (!$this->app->routesAreCached()) {
-            include __DIR__ . '/../routes/routes.php';
-        }
+        // add routes (loadRoutesFrom handles the route-cache check internally)
+        $this->loadRoutesFrom(__DIR__ . '/../routes/routes.php');
 
         // add commands, https://laravel.com/docs/5.4/packages#commands
         $this->addCommands();
@@ -83,8 +80,10 @@ class LaravelServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        // Register MongoDB provider first
-        $this->app->register(MongoDBServiceProvider::class);
+        // Register MongoDB provider first (gated — package is optional)
+        if (class_exists(MongoDBServiceProvider::class)) {
+            $this->app->register(MongoDBServiceProvider::class);
+        }
 
         // merge in df config, https://laravel.com/docs/5.4/packages#resources
         $this->mergeConfigFrom(__DIR__ . '/../config/df.php', 'df');
@@ -117,8 +116,10 @@ class LaravelServiceProvider extends ServiceProvider
         Route::aliasMiddleware('df.access_check', AccessCheck::class);
         Route::aliasMiddleware('df.verb_override', VerbOverrides::class);
 
-        /** Add the first user check to the web group */
-        Route::prependMiddlewareToGroup('web', FirstUserCheck::class);
+        /** Add the first user check to the web group (gated — `web` may not be defined in API-only apps) */
+        if (Route::hasMiddlewareGroup('web')) {
+            Route::prependMiddlewareToGroup('web', FirstUserCheck::class);
+        }
 
         $middleware = [
             'df.verb_override',
@@ -183,7 +184,10 @@ class LaravelServiceProvider extends ServiceProvider
 
     protected function registerOtherProviders()
     {
-        // use CORS
-        $this->app->register(CorsServiceProvider::class);
+        // use CORS (gated — Laravel HandleCors middleware ships in framework so the
+        // provider class is always available, but keep the gate symmetric/defensive)
+        if (class_exists(CorsServiceProvider::class)) {
+            $this->app->register(CorsServiceProvider::class);
+        }
     }
 }

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -80,6 +80,35 @@ class LaravelServiceProvider extends ServiceProvider
      */
     public function register()
     {
+        // PHP 8.5 + Laravel 13 unserialize-time autoload race fix.
+        //
+        // Many df-core / df-database / df-* code paths cache typed objects
+        // (TableSchema, ColumnSchema, RelationSchema, Eloquent\Collection,
+        // CorsConfig models, etc.) via Cache::remember*. On a cache hit the
+        // backing store calls unserialize() to rehydrate the payload — and on
+        // PHP 8.5 there's a class-load race where the schema/model classes
+        // aren't yet known to the autoloader at that exact moment, so PHP
+        // returns __PHP_Incomplete_Class. Subsequent property/method access
+        // on those instances fatals with errors like:
+        //
+        //   "tried to access a property on an incomplete object — please
+        //   ensure that the class definition X was loaded before
+        //   unserialize() gets called"
+        //
+        // We force-load the classes most commonly cached as objects up front,
+        // before any other ServiceProvider can read from the cache. This is a
+        // no-op on PHP 8.3 / Laravel 11 where the same class-load order
+        // happened to be safe.
+        class_exists(\Illuminate\Database\Eloquent\Collection::class);
+        class_exists(\DreamFactory\Core\Database\Schema\TableSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\ColumnSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\RelationSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\NamedResourceSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\FunctionSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\ProcedureSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\ParameterSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\RoutineSchema::class);
+
         // Register MongoDB provider first (gated — package is optional)
         if (class_exists(MongoDBServiceProvider::class)) {
             $this->app->register(MongoDBServiceProvider::class);

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -883,7 +883,17 @@ class BaseModel extends Model
      */
     public function getTableSchema()
     {
-        return \Cache::rememberForever('model:' . $this->table, function () {
+        // PHP 8.5 + Laravel 13 autoload race fix: force-load the schema
+        // classes that may live inside the cached payload. Without this,
+        // unserialize() during Cache::rememberForever can rehydrate them as
+        // __PHP_Incomplete_Class, and downstream property access throws
+        // "tried to access a property on an incomplete object".
+        class_exists(\DreamFactory\Core\Database\Schema\TableSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\ColumnSchema::class);
+        class_exists(\DreamFactory\Core\Database\Schema\RelationSchema::class);
+
+        $cacheKey = 'model:' . $this->table;
+        $tableSchema = \Cache::rememberForever($cacheKey, function () {
             $resourceName = $this->table;
             $name = $resourceName;
             if (empty($schemaName = $this->getDefaultSchema())) {
@@ -905,6 +915,16 @@ class BaseModel extends Model
 
             return $tableSchema;
         });
+
+        // Defensive: if the cached value still came back as a non-TableSchema
+        // (cache cross-contamination, persisted incomplete class), drop and
+        // recompute fresh.
+        if (!$tableSchema instanceof TableSchema) {
+            \Cache::forget($cacheKey);
+            return $this->getTableSchema();
+        }
+
+        return $tableSchema;
     }
 
     public function getSchema()

--- a/src/Models/NoDbModel.php
+++ b/src/Models/NoDbModel.php
@@ -74,15 +74,25 @@ class NoDbModel implements Arrayable, Jsonable, JsonSerializable
         return $casts;
     }
 
-    // not sure why Laravel has these are in the HasAttributes trait instead of the model, but they need simplification
+    // The HasAttributes trait calls $this->getDates() and $this->getDateFormat() internally
+    // during attributesToArray(). The trait's own getDates() implementation depends on
+    // usesTimestamps() / $dates, neither of which NoDbModel inherits (it doesn't extend
+    // Model and doesn't use HasTimestamps). We provide stub overrides that short-circuit
+    // the date handling so attributesToArray() works for this Model-less use case.
+    //
+    // Historical note: Eloquent's Model::getDates() was removed in Laravel 10, but the
+    // method still lives in HasAttributes and is invoked from inside the trait, so the
+    // override remains necessary as long as NoDbModel uses HasAttributes directly.
     public function getDates()
     {
-        return $this->dates;
+        return property_exists($this, 'dates') ? (array) $this->dates : [];
     }
 
     protected function getDateFormat()
     {
-        return $this->dateFormat;
+        return property_exists($this, 'dateFormat') && $this->dateFormat
+            ? $this->dateFormat
+            : 'Y-m-d H:i:s';
     }
 
     /**

--- a/src/Providers/CorsServiceProvider.php
+++ b/src/Providers/CorsServiceProvider.php
@@ -7,7 +7,6 @@ use DreamFactory\Core\Models\CorsConfig;
 use Fruitcake\Cors\CorsService;
 use Illuminate\Http\Middleware\HandleCors;
 use Illuminate\Database\QueryException;
-use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
@@ -31,10 +30,9 @@ class CorsServiceProvider extends ServiceProvider
      * Add the Cors middleware to the router.
      *
      * @param Request $request
-     * @param Kernel  $kernel
      * @throws \Exception
      */
-    public function boot(Request $request, Kernel $kernel)
+    public function boot(Request $request)
     {
         $api_prefix = config('df.api_route_prefix', 'api');
         config(['cors.paths' => [$api_prefix . '/*']]);

--- a/src/Providers/CorsServiceProvider.php
+++ b/src/Providers/CorsServiceProvider.php
@@ -96,10 +96,27 @@ class CorsServiceProvider extends ServiceProvider
      */
     protected function getCorsConfigs()
     {
+        // Force-load Eloquent's Collection class before reading from the cache.
+        // CorsServiceProvider::boot() runs early enough that, if the cache
+        // backend (Redis, file, etc.) returns a serialized Collection, PHP's
+        // unserialize() can fire before the class has been autoloaded — in
+        // which case it returns __PHP_Incomplete_Class, which is unusable.
+        // Touching the class name here triggers PSR-4 autoload up front.
+        class_exists(\Illuminate\Database\Eloquent\Collection::class);
+
         try {
             $cors = Cache::remember(CorsConfig::CACHE_KEY, \Config::get('df.default_cache_ttl'), function (){
                 return CorsConfig::whereEnabled(true)->get();
             });
+
+            // Defensive: if the cached value still came back as something
+            // other than a Collection (cache cross-contamination across
+            // backends, persisted __PHP_Incomplete_Class, etc.), drop the
+            // entry and re-fetch fresh.
+            if (!$cors instanceof \Illuminate\Support\Collection) {
+                Cache::forget(CorsConfig::CACHE_KEY);
+                $cors = CorsConfig::whereEnabled(true)->get();
+            }
 
             return $cors;
         } catch (\Exception $e) {

--- a/src/Testing/TestCase.php
+++ b/src/Testing/TestCase.php
@@ -37,7 +37,7 @@ class TestCase extends LaravelTestCase
     /**
      * Runs before every test class.
      */
-    public static function setupBeforeClass(): void
+    public static function setUpBeforeClass(): void
     {
         echo "\n------------------------------------------------------------------------------\n";
         echo "Running test: " . get_called_class() . "\n";
@@ -110,15 +110,67 @@ class TestCase extends LaravelTestCase
     /**
      * Creates the application.
      *
+     * Consuming applications should override this if the Laravel-style
+     * bootstrap path differs from the conventional `bootstrap/app.php`
+     * relative to the host project root. The base path is resolved from
+     * the consumer's working tree (parent of the running phpunit binary)
+     * rather than the current working directory, so tests can be invoked
+     * from any cwd.
+     *
      * @return \Illuminate\Foundation\Application
      */
     public function createApplication()
     {
-        $app = require './bootstrap/app.php';
+        $bootstrap = $this->resolveBootstrapPath();
 
-        $app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+        /** @var \Illuminate\Foundation\Application $app */
+        $app = require $bootstrap;
+
+        $app->make(\Illuminate\Contracts\Console\Kernel::class)->bootstrap();
 
         return $app;
+    }
+
+    /**
+     * Resolve the path to the Laravel application bootstrap file.
+     *
+     * Order of resolution:
+     *   1. DF_TEST_BOOTSTRAP env var (explicit override)
+     *   2. df-core's own ./bootstrap/app.php (when df-core has its own)
+     *   3. Walk up from this file looking for a vendor/.. host project root
+     *
+     * @return string
+     */
+    protected function resolveBootstrapPath(): string
+    {
+        if ($override = getenv('DF_TEST_BOOTSTRAP')) {
+            return $override;
+        }
+
+        // df-core itself: __DIR__ = src/Testing, so root is two levels up.
+        $localCandidate = dirname(__DIR__, 2) . '/bootstrap/app.php';
+        if (file_exists($localCandidate)) {
+            return $localCandidate;
+        }
+
+        // Installed under a host project's vendor/dreamfactory/df-core/src/Testing
+        // → walk up to the host project root (parent of vendor/).
+        $dir = __DIR__;
+        for ($i = 0; $i < 10; $i++) {
+            $candidate = $dir . '/bootstrap/app.php';
+            if (file_exists($candidate) && is_file($dir . '/artisan')) {
+                return $candidate;
+            }
+            $parent = dirname($dir);
+            if ($parent === $dir) {
+                break;
+            }
+            $dir = $parent;
+        }
+
+        throw new \RuntimeException(
+            'Unable to locate bootstrap/app.php. Set DF_TEST_BOOTSTRAP env var to its absolute path.'
+        );
     }
 
     /**

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Arr;
+
 if (!function_exists('to_bool')) {
     /**
      * Convert any value to boolean value.
@@ -44,7 +46,7 @@ if (!function_exists('array_get_bool')) {
      */
     function array_get_bool($array, $key, $default = false)
     {
-        return to_bool(array_get($array, $key, $default));
+        return to_bool(Arr::get($array, $key, $default));
     }
 }
 
@@ -65,9 +67,9 @@ if (!function_exists('array_by_key_value')) {
     {
         if (is_array($array)) {
             foreach ($array as $item) {
-                if ($value === array_get($item, $key)) {
+                if ($value === Arr::get($item, $key)) {
                     if ($returnKey) {
-                        return array_get($item, $returnKey);
+                        return Arr::get($item, $returnKey);
                     } else {
                         return $item;
                     }
@@ -140,7 +142,7 @@ if (!function_exists('array_get_or')) {
     {
         $out = null;
         foreach ($keys as $key) {
-            $out = array_get($data, $key);
+            $out = Arr::get($data, $key);
             if ($out !== null) {
                 break;
             }


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
