### PR TITLE
df:setup: fail fast in non-interactive mode instead of infinite-looping on invalid password

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -125,15 +125,25 @@ class Setup extends Command
                     $passwordConfirm = ($prompt) ? $this->secret('Re-enter password:') : $password;
                     
                     // Validate password length
-                    if (strlen($password) < 16) {
+                    if (strlen((string) $password) < 16) {
                         $this->error('Password must be at least 16 characters long. Please try again.');
+                        if (!$this->input->isInteractive()) {
+                            // Without a terminal, secret() returns null immediately and
+                            // this loop would spin forever at full CPU.
+                            $this->error('Non-interactive setup cannot prompt for a new password. Re-run df:setup with an --admin_password of at least 16 characters.');
+
+                            return 1;
+                        }
                         $password = null; // Reset password to trigger re-prompt
                         continue;
                     }
-                    
+
                     // Validate password confirmation
                     if ($password !== $passwordConfirm) {
                         $this->error('Passwords do not match. Please try again.');
+                        if (!$this->input->isInteractive()) {
+                            return 1;
+                        }
                         $password = null; // Reset password to trigger re-prompt
                         continue;
                     }
@@ -157,6 +167,10 @@ class Setup extends Command
 
                 if (!$user) {
                     $this->error('Failed to create first admin user.' . print_r($data['errors'], true));
+                    if (!$this->input->isInteractive()) {
+                        // Same options would fail identically on every retry.
+                        return 1;
+                    }
                     $this->info('Please try again...');
                 }
             }


### PR DESCRIPTION
The 16-character password minimum added to `df:setup` in 7.7 re-prompts via `$this->secret()` when validation fails. In non-interactive runs — i.e. **every Docker entrypoint** — `secret()` returns `null` immediately, so a short `--admin_password` makes the validation loop **spin forever at 100% CPU** with no error output; the container never finishes setup. Hit in practice installing the `df-7.7-engineer-testbundle` with a 14-character admin password (the pre-7.7 df-docker docs/examples don't mention the new minimum).

## Changes

- Password length failure: when input is non-interactive, print an actionable error ("Re-run df:setup with an --admin_password of at least 16 characters") and exit 1 instead of looping.
- Password confirmation mismatch: same fail-fast guard.
- `User::createFirstAdmin` failure: stop retrying with identical options when no terminal is attached (same infinite-retry shape one level up).
- `strlen((string) $password)` to avoid PHP 8.1+ deprecation noise when `secret()` returns null.

Interactive behavior is unchanged — a user at a terminal still gets re-prompted.

Worth pairing with a df-docker README note about the new 16-character minimum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)