### PR TITLE
release: 7.7.0 — develop → master cut

### DIFF
--- a/src/Commands/Setup.php
+++ b/src/Commands/Setup.php
@@ -125,15 +125,25 @@ class Setup extends Command
                     $passwordConfirm = ($prompt) ? $this->secret('Re-enter password:') : $password;
                     
                     // Validate password length
-                    if (strlen($password) < 16) {
+                    if (strlen((string) $password) < 16) {
                         $this->error('Password must be at least 16 characters long. Please try again.');
+                        if (!$this->input->isInteractive()) {
+                            // Without a terminal, secret() returns null immediately and
+                            // this loop would spin forever at full CPU.
+                            $this->error('Non-interactive setup cannot prompt for a new password. Re-run df:setup with an --admin_password of at least 16 characters.');
+
+                            return 1;
+                        }
                         $password = null; // Reset password to trigger re-prompt
                         continue;
                     }
-                    
+
                     // Validate password confirmation
                     if ($password !== $passwordConfirm) {
                         $this->error('Passwords do not match. Please try again.');
+                        if (!$this->input->isInteractive()) {
+                            return 1;
+                        }
                         $password = null; // Reset password to trigger re-prompt
                         continue;
                     }
@@ -157,6 +167,10 @@ class Setup extends Command
 
                 if (!$user) {
                     $this->error('Failed to create first admin user.' . print_r($data['errors'], true));
+                    if (!$this->input->isInteractive()) {
+                        // Same options would fail identically on every retry.
+                        return 1;
+                    }
                     $this->info('Please try again...');
                 }
             }

--- a/src/Enums/ServiceRequestorTypes.php
+++ b/src/Enums/ServiceRequestorTypes.php
@@ -27,6 +27,10 @@ class ServiceRequestorTypes extends FactoryEnum
      * @var int Service is being called from the scripting environment
      */
     const SCRIPT = 2; // 0b0010
+    /**
+     * @var int Service is being called by a registered agent identity (df-agents)
+     */
+    const AGENT = 4; // 0b0100
 
     //*************************************************************************
     //* Methods

--- a/src/Events/BaseServiceEvent.php
+++ b/src/Events/BaseServiceEvent.php
@@ -2,13 +2,24 @@
 namespace DreamFactory\Core\Events;
 
 use DreamFactory\Core\Models\Service;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 use Illuminate\Queue\SerializesModels;
 
-abstract class BaseServiceEvent
+abstract class BaseServiceEvent implements ShouldDispatchAfterCommit
 {
     use SerializesModels;
 
     public $service;
+
+    /**
+     * The service name before this change, captured at dispatch time.
+     * The listener runs after commit (ShouldDispatchAfterCommit), by which
+     * point the model's original attributes have been re-synced, so
+     * getOriginal() can no longer surface a rename.
+     *
+     * @var string|null
+     */
+    public $originalName;
 
     /**
      * Create a new event instance.
@@ -18,5 +29,6 @@ abstract class BaseServiceEvent
     public function __construct(Service $service)
     {
         $this->service = $service;
+        $this->originalName = $service->getOriginal('name');
     }
 }

--- a/src/Handlers/Events/ServiceEventHandler.php
+++ b/src/Handlers/Events/ServiceEventHandler.php
@@ -88,7 +88,17 @@ class ServiceEventHandler
      */
     public function handleServiceChangeEvent($event)
     {
-        ServiceManager::purge($event->service->name); // clear out any old config
+        try {
+            ServiceManager::purge($event->service->name); // clear out any old config
+            // On rename, also clear the per-name config cached under the old name.
+            if (!empty($event->originalName) && $event->originalName !== $event->service->name) {
+                Cache::forget('service_mgr:' . $event->originalName);
+            }
+        } catch (\Exception $ex) {
+            // Cache invalidation must never fail the request; TTL on the
+            // service_mgr keys self-heals any entries missed here.
+            Log::error('Failed to purge service cache: ' . $ex->getMessage());
+        }
     }
 
     public function handleQueryExecutedEvent($event)

--- a/src/Http/Middleware/AccessCheck.php
+++ b/src/Http/Middleware/AccessCheck.php
@@ -4,6 +4,7 @@ namespace DreamFactory\Core\Http\Middleware;
 
 use Closure;
 use DreamFactory\Core\Enums\ServiceRequestorTypes;
+use DreamFactory\Core\Enums\ServiceTypeGroups;
 use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\Exceptions\ForbiddenException;
 use DreamFactory\Core\Exceptions\RestException;
@@ -128,7 +129,28 @@ class AccessCheck
      */
     private function isOAuthCallback($service, $method, $component)
     {
-        return str_ends_with($service, '_oauth');
+        // An OAuth/SSO callback service handles its own auth flow, so it is
+        // exempt from the access check. Matching the "_oauth" name suffix ALONE
+        // let ANY service (e.g. an API Builder API whose URL segment ends in
+        // "_oauth") bypass authentication entirely — so also require the service
+        // to genuinely be an OAuth/SSO service type.
+        if (!str_ends_with((string)$service, '_oauth')) {
+            return false;
+        }
+
+        try {
+            $typeName = \ServiceManager::getServiceTypeByName($service);
+            $typeInfo = $typeName ? \ServiceManager::getServiceType($typeName) : null;
+            $group = $typeInfo ? $typeInfo->getGroup() : null;
+
+            return in_array(
+                $group,
+                [ServiceTypeGroups::OAUTH, ServiceTypeGroups::SSO],
+                true
+            );
+        } catch (\Throwable $e) {
+            return false;
+        }
     }
 
     /**

--- a/src/Http/Middleware/TraceResponse.php
+++ b/src/Http/Middleware/TraceResponse.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DreamFactory\Core\Http\Middleware;
+
+use Closure;
+use DreamFactory\Core\Utility\TraceId;
+use Illuminate\Http\Request;
+
+/**
+ * Echoes the platform trace id on every API response so callers (and the
+ * next hop in an agent chain) can propagate it. Sits first in df.api.
+ */
+class TraceResponse
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $response = $next($request);
+
+        if (is_object($response) && isset($response->headers)) {
+            $response->headers->set(TraceId::HEADER, TraceId::get());
+        }
+
+        return $response;
+    }
+}

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -18,6 +18,7 @@ use DreamFactory\Core\Handlers\Events\ServiceEventHandler;
 use DreamFactory\Core\Http\Middleware\AccessCheck;
 use DreamFactory\Core\Http\Middleware\AuthCheck;
 use DreamFactory\Core\Http\Middleware\FirstUserCheck;
+use DreamFactory\Core\Http\Middleware\TraceResponse;
 use DreamFactory\Core\Http\Middleware\VerbOverrides;
 use DreamFactory\Core\Models\BaseModel;
 use DreamFactory\Core\Models\SystemTableModelMapper;
@@ -158,6 +159,7 @@ class LaravelServiceProvider extends ServiceProvider
      */
     protected function addMiddleware()
     {
+        Route::aliasMiddleware('df.trace', TraceResponse::class);
         Route::aliasMiddleware('df.auth_check', AuthCheck::class);
         Route::aliasMiddleware('df.access_check', AccessCheck::class);
         Route::aliasMiddleware('df.verb_override', VerbOverrides::class);
@@ -168,6 +170,7 @@ class LaravelServiceProvider extends ServiceProvider
         }
 
         $middleware = [
+            'df.trace',
             'df.verb_override',
             'df.auth_check',
             'df.access_check'

--- a/src/LaravelServiceProvider.php
+++ b/src/LaravelServiceProvider.php
@@ -19,10 +19,12 @@ use DreamFactory\Core\Http\Middleware\AccessCheck;
 use DreamFactory\Core\Http\Middleware\AuthCheck;
 use DreamFactory\Core\Http\Middleware\FirstUserCheck;
 use DreamFactory\Core\Http\Middleware\VerbOverrides;
+use DreamFactory\Core\Models\BaseModel;
 use DreamFactory\Core\Models\SystemTableModelMapper;
 use DreamFactory\Core\Providers\CorsServiceProvider;
 use DreamFactory\Core\Services\ServiceManager;
 use Illuminate\Database\DatabaseManager;
+use Illuminate\Database\Events\MigrationsEnded;
 use Illuminate\Database\SQLiteConnection;
 use Illuminate\Foundation\AliasLoader;
 use Illuminate\Support\ServiceProvider;
@@ -71,6 +73,21 @@ class LaravelServiceProvider extends ServiceProvider
 
         // subscribe to all listened to events
         Event::subscribe(new ServiceEventHandler());
+
+        // Invalidate cached system table schemas whenever migrations actually
+        // run (package upgrades adding config-table columns). MigrationsEnded
+        // only fires when pending migrations executed; NoPendingMigrations
+        // fires otherwise. Keeps GET system/service_type config_schema fresh
+        // after a deploy without any cache:clear.
+        Event::listen(MigrationsEnded::class, function () {
+            try {
+                BaseModel::bumpSchemaVersion();
+            } catch (\Throwable $e) {
+                // Cache invalidation failure must never fail the migration run;
+                // the TTL backstop on the schema caches covers us.
+                \Log::warning('Failed to bump schema cache version after migrations: ' . $e->getMessage());
+            }
+        });
     }
 
     /**

--- a/src/Models/App.php
+++ b/src/Models/App.php
@@ -139,7 +139,12 @@ class App extends BaseSystemModel
                 break;
 
             case AppTypes::PATH:
-                $launchUrl = url($this->path);
+                // Guard a null/empty path: Laravel's url() with no argument
+                // returns the UrlGenerator object, not a string. That object
+                // holds closures, so it breaks App::getCachedInfo() the moment
+                // a serializing cache store (file/database) tries to cache the
+                // app — every request under a headless, path-less app 500s.
+                $launchUrl = !empty($this->path) ? url($this->path) : '';
                 break;
 
             case AppTypes::URL:

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -44,6 +44,12 @@ class BaseModel extends Model
      * @var string
      */
     protected $defaultSchema;
+    /**
+     * Per-request memo of the schema cache version suffix.
+     *
+     * @var string|null
+     */
+    protected static $schemaVersion;
 
     public function save(array $options = [])
     {
@@ -706,7 +712,10 @@ class BaseModel extends Model
             $schema = $this->getSchema();
             if ($schema->supportsResourceType(DbResourceTypes::TYPE_TABLE_CONSTRAINT)) {
                 $result = $schema->getResourceNames(DbResourceTypes::TYPE_TABLE_CONSTRAINT, $this->getDefaultSchema());
-                \Cache::forever($cacheKey, $result);
+                // TTL (not forever) so out-of-band schema changes (other
+                // nodes, manual ALTERs) age out; migrations on this node
+                // invalidate instantly via bumpSchemaVersion().
+                \Cache::put($cacheKey, $result, \Config::get('df.default_cache_ttl'));
             }
         }
 
@@ -716,12 +725,51 @@ class BaseModel extends Model
     protected function getDefaultSchema()
     {
         if (!$this->defaultSchema) {
-            $this->defaultSchema = \Cache::rememberForever('default_schema', function () {
+            $this->defaultSchema = \Cache::remember('default_schema', \Config::get('df.default_cache_ttl'), function () {
                 return $this->getSchema()->getDefaultSchema();
             });
         }
 
         return $this->defaultSchema;
+    }
+
+    /**
+     * Version suffix for the per-table 'model:<table>' schema cache keys.
+     * Bumped by bumpSchemaVersion() whenever migrations actually run, so
+     * every cached table schema is lazily recomputed after a package
+     * upgrade — no cache:clear required. Memoized per request (one extra
+     * Cache::get at most).
+     *
+     * @return string
+     */
+    public static function getSchemaVersion()
+    {
+        if (null === self::$schemaVersion) {
+            self::$schemaVersion = \Cache::remember('df:schema_version', \Config::get('df.default_cache_ttl'), function () {
+                return (string)time();
+            });
+        }
+
+        return self::$schemaVersion;
+    }
+
+    /**
+     * Invalidate all cached system table schemas. Called after migrations
+     * run (see LaravelServiceProvider::boot()). The file cache store has no
+     * tags and 'model:<table>:v<N>' keys cannot be enumerated, so instead of
+     * forgetting each one we rotate the version suffix.
+     *
+     * ponytail: orphaned 'model:<table>:v<N>' entries from old versions
+     * linger on disk until the file cache is pruned — harmless garbage.
+     * Upgrade path: scheduled prune, or CACHE_STORE=redis with a SCAN-based
+     * delete here.
+     */
+    public static function bumpSchemaVersion()
+    {
+        \Cache::forget('df:schema_version');
+        \Cache::forget('system_table_constraints');
+        \Cache::forget('default_schema');
+        self::$schemaVersion = null;
     }
 
     protected function updateTableWithConstraints(TableSchema $table, $constraints)
@@ -892,8 +940,11 @@ class BaseModel extends Model
         class_exists(\DreamFactory\Core\Database\Schema\ColumnSchema::class);
         class_exists(\DreamFactory\Core\Database\Schema\RelationSchema::class);
 
-        $cacheKey = 'model:' . $this->table;
-        $tableSchema = \Cache::rememberForever($cacheKey, function () {
+        // Version-suffixed key: bumpSchemaVersion() after migrations rotates
+        // the suffix, so upgraded config tables recompute lazily without a
+        // cache:clear. TTL is the backstop for out-of-band schema changes.
+        $cacheKey = 'model:' . $this->table . ':v' . static::getSchemaVersion();
+        $tableSchema = \Cache::remember($cacheKey, \Config::get('df.default_cache_ttl'), function () {
             $resourceName = $this->table;
             $name = $resourceName;
             if (empty($schemaName = $this->getDefaultSchema())) {

--- a/src/Providers/CorsServiceProvider.php
+++ b/src/Providers/CorsServiceProvider.php
@@ -37,15 +37,49 @@ class CorsServiceProvider extends ServiceProvider
     public function boot(Request $request, Kernel $kernel)
     {
         $api_prefix = config('df.api_route_prefix', 'api');
-        config(['cors.paths' => [$api_prefix . '/*']]);
         
         $config = $this->getOptions($request);
+        $this->setLaravelCorsConfig($api_prefix, $config);
+
         $this->app->singleton(CorsService::class, function () use ($config){
             return new DfCorsService($config);
         });
 
         Route::aliasMiddleware('df.cors', HandleCors::class);
         Route::prependMiddlewareToGroup('df.api', 'df.cors');
+    }
+
+    /**
+     * Keep Laravel's CORS middleware aligned with DreamFactory's DB-backed CORS config.
+     *
+     * Laravel's HandleCors middleware calls setOptions(config('cors')) on every
+     * request. Without this, Laravel's framework defaults can replace the
+     * DreamFactory CORS row selected above.
+     *
+     * @param string $apiPrefix
+     * @param array  $options
+     */
+    protected function setLaravelCorsConfig(string $apiPrefix, array $options): void
+    {
+        $corsConfig = array_merge(config('cors', []), [
+            'paths'                    => [$apiPrefix . '/*'],
+            'allowedOrigins'           => $options['allowedOrigins'] ?? [],
+            'allowedOriginsPatterns'   => $options['allowedOriginsPatterns'] ?? [],
+            'allowedHeaders'           => $options['allowedHeaders'] ?? [],
+            'allowedMethods'           => $options['allowedMethods'] ?? [],
+            'exposedHeaders'           => $options['exposedHeaders'] ?? [],
+            'maxAge'                   => $options['maxAge'] ?? 0,
+            'supportsCredentials'      => $options['supportsCredentials'] ?? false,
+            'allowed_origins'          => $options['allowedOrigins'] ?? [],
+            'allowed_origins_patterns' => $options['allowedOriginsPatterns'] ?? [],
+            'allowed_headers'          => $options['allowedHeaders'] ?? [],
+            'allowed_methods'          => $options['allowedMethods'] ?? [],
+            'exposed_headers'          => $options['exposedHeaders'] ?? [],
+            'max_age'                  => $options['maxAge'] ?? 0,
+            'supports_credentials'     => $options['supportsCredentials'] ?? false,
+        ]);
+
+        config(['cors' => $corsConfig]);
     }
 
     /**

--- a/src/Services/DfCorsService.php
+++ b/src/Services/DfCorsService.php
@@ -14,7 +14,10 @@ class DfCorsService extends CorsService
 
     public function setOptions(array $options): void
     {
-        $this->allowedMethodsCopy = $options['allowedMethods'] ?? $options['allowed_methods'] ?? $this->allowedMethodsCopy;
+        $this->allowedMethodsCopy = $this->normalizeAllowedMethods(
+            $options['allowedMethods'] ?? $options['allowed_methods'] ?? $this->allowedMethodsCopy
+        );
+
         parent::setOptions($options);
     }
     
@@ -22,13 +25,30 @@ class DfCorsService extends CorsService
     {
         $response = new Response();
 
-        $requestMethod = strtoupper($request->headers->get('Access-Control-Request-Method'));
-        if(!in_array($requestMethod, $this->allowedMethodsCopy)) {
+        $requestMethod = strtoupper((string)$request->headers->get('Access-Control-Request-Method'));
+        if(!$this->isMethodAllowed($requestMethod)) {
             $response->setStatusCode(405, 'Method not allowed');
         } else {
             $response->setStatusCode(204);
         }
         
         return $this->addPreflightRequestHeaders($response, $request);
+    }
+
+    protected function isMethodAllowed(string $requestMethod): bool
+    {
+        return in_array('*', $this->allowedMethodsCopy, true) ||
+            in_array($requestMethod, $this->allowedMethodsCopy, true);
+    }
+
+    protected function normalizeAllowedMethods($methods): array
+    {
+        if (!is_array($methods)) {
+            $methods = [$methods];
+        }
+
+        return array_map(static function ($method) {
+            return strtoupper(trim((string)$method));
+        }, $methods);
     }
 }

--- a/src/Services/ServiceManager.php
+++ b/src/Services/ServiceManager.php
@@ -84,12 +84,13 @@ class ServiceManager
     public function getServiceIdNameMap($only_active = false)
     {
         if ($only_active) {
-            return \Cache::rememberForever('service_mgr:id_name_map_active', function () {
-                return Service::whereIsActive(true)->pluck('name', 'id')->toArray();
-            });
+            return \Cache::remember('service_mgr:id_name_map_active', \Config::get('df.default_cache_ttl'),
+                function () {
+                    return Service::whereIsActive(true)->pluck('name', 'id')->toArray();
+                });
         }
 
-        return \Cache::rememberForever('service_mgr:id_name_map', function () {
+        return \Cache::remember('service_mgr:id_name_map', \Config::get('df.default_cache_ttl'), function () {
             return Service::pluck('name', 'id')->toArray();
         });
     }
@@ -148,12 +149,13 @@ class ServiceManager
     public function getServiceNameTypeMap($only_active = false)
     {
         if ($only_active) {
-            return \Cache::rememberForever('service_mgr:name_type_map_active', function () {
-                return Service::whereIsActive(true)->pluck('type', 'name')->toArray();
-            });
+            return \Cache::remember('service_mgr:name_type_map_active', \Config::get('df.default_cache_ttl'),
+                function () {
+                    return Service::whereIsActive(true)->pluck('type', 'name')->toArray();
+                });
         }
 
-        return \Cache::rememberForever('service_mgr:name_type_map', function () {
+        return \Cache::remember('service_mgr:name_type_map', \Config::get('df.default_cache_ttl'), function () {
             return Service::pluck('type', 'name')->toArray();
         });
     }
@@ -752,7 +754,7 @@ class ServiceManager
             throw new InvalidArgumentException("Service 'name' can not be empty.");
         }
 
-        return \Cache::rememberForever('service_mgr:' . $name, function () use ($name) {
+        return \Cache::remember('service_mgr:' . $name, \Config::get('df.default_cache_ttl'), function () use ($name) {
             /** @var Service $service */
             if (empty($service = Service::whereName($name)->first())) {
                 throw new NotFoundException("Could not find a service for $name");

--- a/src/Utility/TraceId.php
+++ b/src/Utility/TraceId.php
@@ -19,7 +19,11 @@ class TraceId
     public static function get(): string
     {
         if (self::$id === null) {
-            $inbound = request()?->header(self::HEADER);
+            // request() throws outside an HTTP context (artisan, queue workers,
+            // bare unit-test containers) — those hops mint a fresh id instead.
+            $inbound = app()->bound('request')
+                ? request()?->header(self::HEADER)
+                : null;
             self::$id = self::isValid($inbound) ? $inbound : (string) Str::uuid();
         }
 

--- a/src/Utility/TraceId.php
+++ b/src/Utility/TraceId.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace DreamFactory\Core\Utility;
+
+use Illuminate\Support\Str;
+
+/**
+ * Platform-wide trace id: one id per inbound request, propagated across
+ * chat -> MCP -> REST hops via the X-DreamFactory-Trace-Id header, so every
+ * audit row produced by one agent action (ai_usage_log, ai_prompt_log,
+ * mcp_request_log, ...) can be joined into a single trace.
+ */
+class TraceId
+{
+    public const HEADER = 'X-DreamFactory-Trace-Id';
+
+    private static ?string $id = null;
+
+    public static function get(): string
+    {
+        if (self::$id === null) {
+            $inbound = request()?->header(self::HEADER);
+            self::$id = self::isValid($inbound) ? $inbound : (string) Str::uuid();
+        }
+
+        return self::$id;
+    }
+
+    /**
+     * Accept a sane external id (agents, gateways, retries of parked tasks)
+     * without letting a caller inject junk into audit rows.
+     */
+    private static function isValid(?string $id): bool
+    {
+        return is_string($id) && preg_match('/^[A-Za-z0-9._-]{8,64}$/', $id) === 1;
+    }
+
+    /** Testing/long-running-worker hook; a normal PHP-FPM request never needs it. */
+    public static function reset(): void
+    {
+        self::$id = null;
+    }
+}

--- a/tests/DfCorsServiceTest.php
+++ b/tests/DfCorsServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use DreamFactory\Core\Services\DfCorsService;
+use Symfony\Component\HttpFoundation\Request;
+
+class DfCorsServiceTest extends \DreamFactory\Core\Testing\TestCase
+{
+    public function testPreflightAllowsConfiguredMethod()
+    {
+        $service = new DfCorsService([
+            'allowedOrigins' => ['*'],
+            'allowedHeaders' => ['*'],
+            'allowedMethods' => ['GET', 'POST'],
+        ]);
+
+        $response = $service->handlePreflightRequest($this->makePreflightRequest('POST'));
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testPreflightRejectsUnconfiguredMethod()
+    {
+        $service = new DfCorsService([
+            'allowedOrigins' => ['*'],
+            'allowedHeaders' => ['*'],
+            'allowedMethods' => ['GET'],
+        ]);
+
+        $response = $service->handlePreflightRequest($this->makePreflightRequest('POST'));
+
+        $this->assertEquals(405, $response->getStatusCode());
+    }
+
+    public function testPreflightAllowsWildcardMethodFromLaravelConfig()
+    {
+        $service = new DfCorsService([
+            'allowed_origins' => ['*'],
+            'allowed_headers' => ['*'],
+            'allowed_methods' => ['*'],
+        ]);
+
+        $response = $service->handlePreflightRequest($this->makePreflightRequest('PATCH'));
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    public function testPreflightNormalizesConfiguredMethods()
+    {
+        $service = new DfCorsService([
+            'allowedOrigins' => ['*'],
+            'allowedHeaders' => ['*'],
+            'allowedMethods' => [' post '],
+        ]);
+
+        $response = $service->handlePreflightRequest($this->makePreflightRequest('POST'));
+
+        $this->assertEquals(204, $response->getStatusCode());
+    }
+
+    protected function makePreflightRequest(string $method): Request
+    {
+        return Request::create('/api/v2/system/environment', 'OPTIONS', [], [], [], [
+            'HTTP_ORIGIN' => 'https://example.com',
+            'HTTP_ACCESS_CONTROL_REQUEST_METHOD' => $method,
+            'HTTP_ACCESS_CONTROL_REQUEST_HEADERS' => 'x-dreamfactory-api-key,content-type',
+        ]);
+    }
+}

--- a/tests/Security/OAuthBypassTest.php
+++ b/tests/Security/OAuthBypassTest.php
@@ -2,25 +2,50 @@
 
 namespace DreamFactory\Core\Tests\Security;
 
-use DreamFactory\Core\Http\Middleware\AccessCheck;
+use DreamFactory\Core\Enums\ServiceTypeGroups;
 use DreamFactory\Core\Enums\Verbs;
-use PHPUnit\Framework\TestCase;
+use DreamFactory\Core\Facades\ServiceManager;
+use DreamFactory\Core\Http\Middleware\AccessCheck;
+use DreamFactory\Core\Testing\TestCase;
 
 /**
- * Tests that the OAuth bypass in AccessCheck correctly identifies _oauth services.
+ * Tests that the OAuth bypass in AccessCheck only exempts services that are
+ * GENUINELY OAuth/SSO types.
  *
- * Services ending in _oauth handle their own authentication (OAuth provider flows)
- * and must bypass DreamFactory's access checks for all methods and resources.
- * Non-_oauth services must never be bypassed.
+ * Services that run their own OAuth/SSO provider flows must bypass DreamFactory's
+ * access check (the callback arrives before the user has a session). Previously
+ * the bypass matched on the "_oauth" name suffix ALONE, which let ANY service
+ * named *_oauth (e.g. a database service, or an API Builder API whose URL
+ * segment ended in "_oauth") skip authentication entirely. The check now also
+ * requires the service's type group to be OAuth or SSO.
+ *
+ * Extends the framework TestCase so the application (and the ServiceManager
+ * facade) is booted — isOAuthCallback resolves the \ServiceManager facade, so
+ * without a booted app the facade alias would not exist and every lookup would
+ * fall into the catch block. stage() is a no-op: this is a pure logic test and
+ * needs no migrations or seed data.
  */
 class OAuthBypassTest extends TestCase
 {
-    private AccessCheck $middleware;
+    /** @var AccessCheck */
+    private $middleware;
+
+    /** No DB needed for this unit test. */
+    public function stage()
+    {
+        // intentionally empty — skip migrate/seed
+    }
 
     public function setUp(): void
     {
         parent::setUp();
         $this->middleware = new AccessCheck();
+    }
+
+    public function tearDown(): void
+    {
+        ServiceManager::clearResolvedInstances();
+        parent::tearDown();
     }
 
     /**
@@ -33,29 +58,59 @@ class OAuthBypassTest extends TestCase
         return $reflection->invoke($this->middleware, $service, $method, $component);
     }
 
-    // === Should ALLOW (_oauth-suffixed services) ===
-
-    public function testAllowsOAuthServiceGet(): void
+    /**
+     * Swap a ServiceManager so any service name resolves to the given type group.
+     * Pass null to simulate a service/type that does not exist.
+     */
+    private function fakeServiceGroup(?string $group): void
     {
+        if ($group === null) {
+            ServiceManager::shouldReceive('getServiceTypeByName')->andReturn(null);
+            return;
+        }
+
+        ServiceManager::shouldReceive('getServiceTypeByName')->andReturn('mock_type');
+        $type = \Mockery::mock();
+        $type->shouldReceive('getGroup')->andReturn($group);
+        ServiceManager::shouldReceive('getServiceType')->andReturn($type);
+    }
+
+    // === Should ALLOW: genuine OAuth/SSO services named *_oauth ===
+
+    public function testAllowsRealOAuthServiceAnyMethodOrResource(): void
+    {
+        $this->fakeServiceGroup(ServiceTypeGroups::OAUTH);
+
         $this->assertTrue($this->isOAuthCallback('github_oauth', Verbs::GET, 'sso'));
-    }
-
-    public function testAllowsOAuthServicePost(): void
-    {
         $this->assertTrue($this->isOAuthCallback('github_oauth', Verbs::POST, 'callback'));
-    }
-
-    public function testAllowsOAuthServiceAnyResource(): void
-    {
         $this->assertTrue($this->isOAuthCallback('google_oauth', Verbs::GET, 'anything'));
-    }
-
-    public function testAllowsOAuthServiceRoot(): void
-    {
         $this->assertTrue($this->isOAuthCallback('azure_oauth', Verbs::GET, ''));
     }
 
-    // === Should DENY (non-_oauth services) ===
+    public function testAllowsRealSsoService(): void
+    {
+        $this->fakeServiceGroup(ServiceTypeGroups::SSO);
+
+        $this->assertTrue($this->isOAuthCallback('company_oauth', Verbs::GET, 'sso'));
+    }
+
+    // === Should DENY: *_oauth name but NOT an OAuth/SSO type (the bypass exploit) ===
+
+    public function testDeniesImpostorOAuthNamedDataService(): void
+    {
+        $this->fakeServiceGroup(ServiceTypeGroups::DATABASE);
+
+        $this->assertFalse($this->isOAuthCallback('evil_oauth', Verbs::GET, '_table/users'));
+    }
+
+    public function testDeniesNonexistentOAuthNamedService(): void
+    {
+        $this->fakeServiceGroup(null);
+
+        $this->assertFalse($this->isOAuthCallback('ghost_oauth', Verbs::GET, ''));
+    }
+
+    // === Should DENY: not even _oauth-suffixed (short-circuits before any lookup) ===
 
     public function testDeniesNonOAuthService(): void
     {


### PR DESCRIPTION
7.7.0 release cut. Highlights: platform-wide request tracing + AGENT requestor type, CORS preflight fix, non-interactive df:setup fail-fast, service/config cache reliability fixes, _oauth-suffix auth-bypass fix. (1.0.17 stays inside the ~1.0.x pins used by several connectors.)

After merge, tag **1.0.17** on the merge commit (df-commercial's version refresh consumes the tags). Full release notes: see the 7.7.0 draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)