### PR TITLE
fix(security): harden curl SSRF/TLS defaults and gate service-type catalog

### DIFF
--- a/src/Http/Controllers/RestController.php
+++ b/src/Http/Controllers/RestController.php
@@ -79,21 +79,26 @@ class RestController extends Controller
                 }
             }
 
-            if (!empty($group)) {
-                $results = ServiceManager::getServiceTypes($group);
-            } elseif (!empty($type)) {
-                $results = [ServiceManager::getServiceType($type)];
-            } else {
-                $results = ServiceManager::getServiceTypes();
-            }
+            // The list of installed service types is only exposed to
+            // authenticated callers. It is not needed by anonymous callers and
+            // reveals which connectors are installed on the instance.
             $types = [];
-            foreach ($results as $type) {
-                $types[] = [
-                    'name'        => $type->getName(),
-                    'label'       => $type->getLabel(),
-                    'group'       => $type->getGroup(),
-                    'description' => $type->getDescription()
-                ];
+            if (Session::isAuthenticated()) {
+                if (!empty($group)) {
+                    $results = ServiceManager::getServiceTypes($group);
+                } elseif (!empty($type)) {
+                    $results = [ServiceManager::getServiceType($type)];
+                } else {
+                    $results = ServiceManager::getServiceTypes();
+                }
+                foreach ($results as $type) {
+                    $types[] = [
+                        'name'        => $type->getName(),
+                        'label'       => $type->getLabel(),
+                        'group'       => $type->getGroup(),
+                        'description' => $type->getDescription()
+                    ];
+                }
             }
             $response = ResponseFactory::create(['services' => $services, 'service_types' => $types]);
             Log::info('[RESPONSE]', ['Status Code' => $response->getStatusCode(), 'Content-Type' => $response->getContentType()]);

--- a/src/Utility/Curl.php
+++ b/src/Utility/Curl.php
@@ -1,6 +1,7 @@
 <?php namespace DreamFactory\Core\Utility;
 
 use DreamFactory\Core\Enums\Verbs;
+use DreamFactory\Core\System\Components\SsrfValidator;
 
 /**
  * Curl
@@ -199,16 +200,18 @@ class Curl extends Verbs
         //	Reset!
         static::$_lastResponseHeaders = static::$_lastHttpCode = static::$_error = static::$_info = $_tmpFile = null;
 
-        //	Build a curl request...
-        $_curl = curl_init($url);
-
         //	Default CURL options for this method
+        //  Redirects are not followed automatically. Each hop is checked and
+        //  followed manually below so a redirect cannot reach an internal host.
+        //  SSL peer/host verification is on by default.
         $_curlOptions = [
-            CURLOPT_FOLLOWLOCATION => true,
+            CURLOPT_FOLLOWLOCATION => false,
+            CURLOPT_MAXREDIRS      => 0,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_HEADER         => true,
             CURLINFO_HEADER_OUT    => true,
-            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYPEER => true,
+            CURLOPT_SSL_VERIFYHOST => 2,
             CURLOPT_TIMEOUT => 300  // 5 minutes default (can be overridden via service options)
         ];
 
@@ -275,16 +278,46 @@ class Curl extends Verbs
             $_curlOptions[CURLOPT_PORT] = static::$_hostPort;
         }
 
-        //	Set our collected options
-        curl_setopt_array($_curl, $_curlOptions);
+        //  Capture the caller's redirect preference, then always disable cURL's
+        //  automatic following so each hop is validated before it is requested.
+        $_followRedirects = true;
+        if (array_key_exists(CURLOPT_FOLLOWLOCATION, $_curlOptions)) {
+            $_followRedirects = (bool)$_curlOptions[CURLOPT_FOLLOWLOCATION];
+        }
+        $_curlOptions[CURLOPT_FOLLOWLOCATION] = false;
+        $_curlOptions[CURLOPT_MAXREDIRS] = 0;
 
-        //	Make the call!
-        $_result = curl_exec($_curl);
+        //	Make the call, following any redirects manually.
+        $_redirectCount = 0;
+        $_maxRedirects = 10;
 
-        static::$_info = curl_getinfo($_curl);
-        static::$_lastHttpCode = array_get(static::$_info, 'http_code');
-        static::$_responseHeaders = curl_getinfo($_curl, CURLINFO_HEADER_OUT);
-        static::$_responseHeadersSize = curl_getinfo($_curl, CURLINFO_HEADER_SIZE);
+        while (true) {
+            //	Build a curl request...
+            $_curl = curl_init($url);
+
+            //	Set our collected options
+            curl_setopt_array($_curl, $_curlOptions);
+
+            $_result = curl_exec($_curl);
+
+            static::$_info = curl_getinfo($_curl);
+            static::$_lastHttpCode = array_get(static::$_info, 'http_code');
+            static::$_responseHeaders = curl_getinfo($_curl, CURLINFO_HEADER_OUT);
+            static::$_responseHeadersSize = curl_getinfo($_curl, CURLINFO_HEADER_SIZE);
+
+            //  Follow a redirect only after confirming the target is not a
+            //  private, loopback, or link-local address.
+            $_redirectUrl = array_get(static::$_info, 'redirect_url');
+            if ($_followRedirects && !empty($_redirectUrl) && $_redirectCount < $_maxRedirects) {
+                SsrfValidator::validateExternalUrl($_redirectUrl);
+                $url = $_redirectUrl;
+                $_redirectCount++;
+                @curl_close($_curl);
+                continue;
+            }
+
+            break;
+        }
 
         if (false === $_result) {
             static::$_error = [

--- a/src/Utility/Curl.php
+++ b/src/Utility/Curl.php
@@ -1,6 +1,7 @@
 <?php namespace DreamFactory\Core\Utility;
 
 use DreamFactory\Core\Enums\Verbs;
+use DreamFactory\Core\Exceptions\BadRequestException;
 use DreamFactory\Core\System\Components\SsrfValidator;
 
 /**
@@ -203,7 +204,11 @@ class Curl extends Verbs
         //	Default CURL options for this method
         //  Redirects are not followed automatically. Each hop is checked and
         //  followed manually below so a redirect cannot reach an internal host.
-        //  SSL peer/host verification is on by default.
+        //  SSL peer/host verification is on by default. Callers that must talk
+        //  to a self-signed or internal endpoint can opt out per request by
+        //  passing CURLOPT_SSL_VERIFYPEER => false (and CURLOPT_SSL_VERIFYHOST
+        //  => 0) in $curlOptions; the merge below lets those values win. For a
+        //  remote web service, set the same keys in the service "options" list.
         $_curlOptions = [
             CURLOPT_FOLLOWLOCATION => false,
             CURLOPT_MAXREDIRS      => 0,
@@ -306,10 +311,13 @@ class Curl extends Verbs
             static::$_responseHeadersSize = curl_getinfo($_curl, CURLINFO_HEADER_SIZE);
 
             //  Follow a redirect only after confirming the target is not a
-            //  private, loopback, or link-local address.
+            //  private, loopback, or link-local address. The hop is validated
+            //  and curl is pinned to the exact IP that was checked, so DNS
+            //  cannot be re-pointed at an internal host between the check and
+            //  the connection.
             $_redirectUrl = array_get(static::$_info, 'redirect_url');
             if ($_followRedirects && !empty($_redirectUrl) && $_redirectCount < $_maxRedirects) {
-                SsrfValidator::validateExternalUrl($_redirectUrl);
+                static::validateAndPinRedirect($_redirectUrl, $_curlOptions);
                 $url = $_redirectUrl;
                 $_redirectCount++;
                 @curl_close($_curl);
@@ -428,6 +436,64 @@ class Curl extends Verbs
         }
 
         return $_result;
+    }
+
+    /**
+     * Validate a redirect target and pin curl to the exact IP that was
+     * checked. Resolving once and pinning with CURLOPT_RESOLVE means the IP
+     * curl connects to is the same one that passed the address checks, closing
+     * the DNS-rebind window between validation and connection. The hostname is
+     * kept for SNI and certificate verification.
+     *
+     * Only IPv4 targets are pinned. Other targets still pass through the full
+     * validateExternalUrl() check; they just are not pinned here.
+     *
+     * @param string $url         The redirect target URL.
+     * @param array  $curlOptions Current curl options, updated in place with a
+     *                            CURLOPT_RESOLVE pin when an IPv4 address is found.
+     *
+     * @throws BadRequestException When the target fails the address checks.
+     * @return void
+     */
+    protected static function validateAndPinRedirect($url, array &$curlOptions)
+    {
+        //  Full URL safety check: scheme, host encoding, IPv6, resolved range.
+        SsrfValidator::validateExternalUrl($url);
+
+        $_parts = parse_url($url);
+        $_host = array_get($_parts, 'host');
+        if (empty($_host)) {
+            return;
+        }
+        //  Strip IPv6 brackets.
+        $_host = ltrim(rtrim($_host, ']'), '[');
+
+        //  Resolve to an IPv4 address. Only IPv4 can be pinned here; for any
+        //  other case leave DNS to curl (the check above already validated it).
+        if (filter_var($_host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            $_ip = $_host;
+        } else {
+            $_ip = gethostbyname($_host);
+            if (!filter_var($_ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                return;
+            }
+        }
+
+        //  The exact IP we will connect to must itself pass the range check.
+        //  This catches a rebind between the check above and this resolve.
+        if (SsrfValidator::isPrivateOrReservedIp($_ip)) {
+            throw new BadRequestException(
+                'Invalid redirect: the target resolves to a private or reserved address.'
+            );
+        }
+
+        $_scheme = strtolower((string)array_get($_parts, 'scheme'));
+        $_port = array_get($_parts, 'port');
+        if (empty($_port)) {
+            $_port = ($_scheme === 'https') ? 443 : 80;
+        }
+
+        $curlOptions[CURLOPT_RESOLVE] = [$_host . ':' . $_port . ':' . $_ip];
     }
 
     /**


### PR DESCRIPTION
Curl.php shipped FOLLOWLOCATION=true, SSL_VERIFYPEER=false. Now FOLLOWLOCATION=false, MAXREDIRS=0, VERIFYPEER=true, VERIFYHOST=2; redirects followed manually with per-hop SsrfValidator + DNS-pin via CURLOPT_RESOLVE. GET /api/v2/ catalog now gated behind isAuthenticated() (login UI unaffected). SHIP-TOGETHER: imports df-system SsrfValidator (on df-system develop) -> merge in the same release train or the redirect path fatals. Cherry-picked clean off acp/integration.

Validated during 2026-08-25 pentest handoff. Details + follow-ups: df-pentest-7.7/HANDOFF-KEVIN-CODY.md

https://claude.ai/code/session_01Mbf33BMddwdar9WbjWJvgo